### PR TITLE
Update SpatieTagsInput.php

### DIFF
--- a/src/Forms/Components/SpatieTagsInput.php
+++ b/src/Forms/Components/SpatieTagsInput.php
@@ -66,6 +66,7 @@ class SpatieTagsInput extends TagsInput
                 fn (Builder $query) => $query->where('type', $type),
                 fn (Builder $query) => $query->where('type', null),
             )
+            ->limit(50)
             ->pluck('name')
             ->toArray();
     }


### PR DESCRIPTION
This will reduce the number of tags loaded at once, making the page faster to load.

![Screenshot 2023-07-07 at 11 06 52 AM](https://github.com/filamentphp/spatie-laravel-tags-plugin/assets/5415880/1e8d9c3b-882f-460f-a3f8-de240367d636)
