### PR TITLE
Return suggestions when the $type is not set on SpatieTagsInput

### DIFF
--- a/src/Forms/Components/SpatieTagsInput.php
+++ b/src/Forms/Components/SpatieTagsInput.php
@@ -63,8 +63,7 @@ class SpatieTagsInput extends TagsInput
         return $tagClass::query()
             ->when(
                 filled($type),
-                fn (Builder $query) => $query->where('type', $type),
-                fn (Builder $query) => $query->where('type', null),
+                fn (Builder $query) => $query->where('type', $type)
             )
             ->pluck('name')
             ->toArray();


### PR DESCRIPTION
If there is no type set on the SpatieTagsInput component and tags records have types, the suggestions do not work. This is because the suggestions query adds a condition that a type should be NULL if it is not set. By removing this condition, the suggestions always return all types if no type is set. I believe this is the correct behaviour.